### PR TITLE
Add missing CMakeLists.txt to Math directory

### DIFF
--- a/XLEngine/Math/CMakeLists.txt
+++ b/XLEngine/Math/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(xlengine
+                PRIVATE
+                    "${CMAKE_CURRENT_SOURCE_DIR}/crc32.cpp")
+


### PR DESCRIPTION
Running cmake now completes without error with this missing cmake file.